### PR TITLE
Refactor: Clean up redundant CSS in index.css

### DIFF
--- a/index.css
+++ b/index.css
@@ -19,7 +19,6 @@ body {
   background: transparent;
   max-width: 80%;
   margin: auto;
-  border: none;
   border-radius: 10px;
   display: flex;
   flex-direction: column;
@@ -99,8 +98,7 @@ button::before {
   filter: blur(1.5rem);
   opacity: 0.5;
 }
-button:focus,
-button:focus-visible {
+button:focus, button:focus-visible {
   outline: none;
   box-shadow: none;
 }
@@ -141,7 +139,6 @@ p {
   }
   p {
     font-weight: bold;
-    /* color: #8ffa04; */
     color: white;
     font-size: 1.3em;
   }
@@ -154,8 +151,6 @@ p {
     }
   }
   button {
-    outline: none;
-    -webkit-tap-highlight-color: transparent;
     width: 150px;
     height: 150px;
     padding: 50px 50px;
@@ -166,16 +161,6 @@ p {
     box-sizing: border-box;
     position: relative;
     animation: glow 2s ease-in-out infinite alternate;
-  }
-  button:focus,
-  button:focus-visible {
-    outline: none;
-    box-shadow: none;
-  }
-  @property --angle {
-    syntax: "<angle>";
-    initial-value: 0deg;
-    inherits: false;
   }
   button::after,
   button::before {
@@ -201,14 +186,6 @@ p {
     padding: 2px;
     /* animation: 3s spin linear infinite; */
     animation: 3s spin ease-in-out infinite;
-  }
-  @keyframes spin {
-    from {
-      --angle: 0deg;
-    }
-    to {
-      --angle: 360deg;
-    }
   }
   @keyframes revSpin {
     from {


### PR DESCRIPTION
I removed several instances of redundant CSS properties and rules in index.css to improve readability and maintainability for you.

Specifically, I made the following changes:
- Removed duplicate `border: none;` from `.container`.
- Consolidated `button:focus` and `button:focus-visible` rules and removed a duplicated version from the media query.
- Removed redundant `outline: none;` and `-webkit-tap-highlight-color: transparent;` from `button` within the media query.
- Removed redundant `@property --angle` and `@keyframes spin` from the media query.
- Confirmed that `button::before` and `#save-btn::before` in the media query were already consolidated.
- Removed a commented-out `color` property from the `p` tag within the media query.